### PR TITLE
Interface change, porting of CaesarCipher to the new interface

### DIFF
--- a/App/CeasarCipher.php
+++ b/App/CeasarCipher.php
@@ -13,41 +13,37 @@ class CeasarCipher extends CipherBaseClass implements CipherInterface
 
     /**
      * CeasarCipher constructor.
-     * @param string $cipherText
      * @param int $key
      */
 
-    public function __construct(string $cipherText, int $key)
+    public function __construct(int $key)
     {
-        parent::__construct($cipherText);
         $this->key = $key;
     }
 
-    private function shiftingChars(): string
+    private function shiftingChars(int $shiftBy, string $theText): string
     {
         $outputText = '';
-        $inputArray = str_split($this->cipherText);
+        $inputArray = str_split($theText);
         foreach ($inputArray as $inputChar) {
             if (!ctype_alpha($inputChar)) {
                 $cipheredChar = $inputChar;
             } else {
                 $offsetValue  = ord(ctype_upper($inputChar) ? 'A' : 'a');
-                $cipheredChar = chr((((ord($inputChar) + $this->key) - $offsetValue) % 26) + $offsetValue);
+                $cipheredChar = chr((((ord($inputChar) + $shiftBy) - $offsetValue) % 26) + $offsetValue);
             }
             $outputText .= $cipheredChar;
         }
         return $outputText;
     }
 
-    public function decrypt(): string
+    public function decrypt(string $cipherText): string
     {
-        $this->key = 26 - $this->key;
-        return $this->shiftingChars();
+        return $this->shiftingChars(26 - $this->key, $cipherText);
     }
 
-    public function encrypt(): string
+    public function encrypt(string $plainText): string
     {
-        return $this->shiftingChars();
-
+        return $this->shiftingChars($this->key, $plainText);
     }
 }

--- a/App/CipherInterface.php
+++ b/App/CipherInterface.php
@@ -7,7 +7,7 @@ namespace App;
 interface CipherInterface
 {
 
-    public function encrypt();
+    public function encrypt(string $plainText);
 
-    public function decrypt();
+    public function decrypt(string $cipherText);
 }

--- a/index.php
+++ b/index.php
@@ -34,14 +34,14 @@ do {
             exit("ERROR : Cipher key entered empty !!" . PHP_EOL);
         }
     }
-    $newclass = new CeasarCipher($inputText, (int)$cipherKey);    // be default
+    $newclass = new CeasarCipher((int)$cipherKey);    // be default
     if ($cipherType === 'V') {
         $newclass = new VigenereCipher($inputText, $cipherKey);
     }
     if ($cipherMethod === 'D') {
-        $results = $newclass->decrypt();
+        $results = $newclass->decrypt($inputText);
     } else {
-        $results = $newclass->encrypt();
+        $results = $newclass->encrypt($inputText);
     }
     echo "Original Text entered          => $inputText \n";
     echo "Ciphered Text                  => $results \n";


### PR DESCRIPTION
Hi Bal,

Here's what I was talking about in keeping the data with the operation in the Interface. As you can see, the encrypt and decrypt methods take the plain / cipher text respectively.

See if you can make a start on doing the same for the other implementation.

On the Vigenère cipher - one tip there is that you don't need the full stream of your key to obtain a shift distance.

E.g. if my key is "mark" and your plaintext is "Hello Bal",  you can use the position within the first string to work out which key char to use for your shift distance.

Yes, "Hello Bal" is longer than "mark", but you can use the modulo operator to get around that. See if you can figure out how 🙂 